### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: E2E Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/webdevbyjoss/TravelSplit/security/code-scanning/1](https://github.com/webdevbyjoss/TravelSplit/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. Since the workflow only checks out code and runs tests, it does not need write access to repository contents or other resources. The best fix is to add `permissions: contents: read` at the root level of the workflow (above `jobs:`), which will apply to all jobs unless overridden. This change should be made at the top of the `.github/workflows/e2e.yml` file, after the `name:` and before `on:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Adjusted GitHub Actions workflow permissions so the pipeline’s GITHUB_TOKEN has read-only access to repository contents. No changes to triggers, steps, or jobs. Build and deployment behavior remains the same, with no effect on app functionality or user experience. This update confines CI to read operations when interacting with the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->